### PR TITLE
fix: corrige erro de não resetar game e desabilita flip de 3+ cartas

### DIFF
--- a/src/games/memory/logic/MemoryGameLogic.ts
+++ b/src/games/memory/logic/MemoryGameLogic.ts
@@ -286,6 +286,14 @@ export class MemoryGameLogic {
 
         if (cardFlipped || cardAnimating) return;
 
+        const flippedCards = this.cards.filter(
+          (c) => c.getData("flipped") && !c.getData("matched"),
+        );
+
+        if (flippedCards.length >= 2) {
+          return;
+        }
+
         this.flipCard(card, true, () => {
           const flippedCards = this.cards.filter(
             (c) => c.getData("flipped") && c !== card && !c.getData("matched"),

--- a/src/games/memory/scenes/GameScene.ts
+++ b/src/games/memory/scenes/GameScene.ts
@@ -120,6 +120,7 @@ export class MemoryGameScene extends PreloadScene {
           this.logic.finishLevel(); // Incrementa o nível
 
           if (isLastLevel) {
+            this.registry.set("currentLevel", 0);
             // Era o último nível, jogo acabou
             this.scene.start("EndScene");
           } else {


### PR DESCRIPTION

# Descrição

Essa PR corrige o erro de não resetar as questões quando o usuario termina o jogo e desabilita as cartas quando 2 já estão selecionadas.

Essa PR endereça a(s) tarefa(s) #<task_id>, #<task_id>, #<task_id>...

Essa PR tem como dependências o(s) PR(s) #<pr_id>, #<pr_id>, #<pr_id>...

# Tipo de alterações realizadas

<Marque todas as opções relevantes>

- [X] Correção de bug (alteração que corrige um problema)
- [ ] Novo recurso (adição de novas funcionalidades)
- [ ] Refatoração (uma mudança no código que não corrige um problema nem adiciona novas funcionalidades)
- [ ] Breaking change (correção ou nova funcionalidade que pode causar mau funcionamento de outras funcionalidades existentes)
- [ ] Atualizações de tarefas de build, configurações de administrador, pacotes... (como por exemplo adicionar um pacote no gitignore.)

# Como testar

<Por favor, descreva quaisquer instruções relevantes para executar, testar e verificar as mudanças feitas.>

# Checklist

- [ ] Meu código segue as diretrizes de estilo especificadas no guia de estilo do projeto
- [ ] Realizei a revisão do meu próprio código
- [ ] Realizei as alterações necessárias na documentação
- [ ] Minhas mudanças não geram novos "code warnings" ou erros
- [ ] Adicionei testes que cobrem o novo código adicionado
- [ ] Os novos testes e também os já existentes passam localmente com minhas mudanças
