### PR TITLE
feat: adiciona quebra de linha nos botões que são apenas texto

### DIFF
--- a/src/games/hygiene/logic/HygieneLogic.ts
+++ b/src/games/hygiene/logic/HygieneLogic.ts
@@ -396,40 +396,6 @@ export default class HygieneLogic {
   }
 
   /**
-   * Função auxiliar para quebrar texto em múltiplas linhas
-   */
-  private wrapText(text: string, maxLineLength: number = 14): string {
-    const words = text.split(" ");
-    const lines: string[] = [];
-    let currentLine = "";
-
-    words.forEach((word) => {
-      // Se adicionar esta palavra ultrapassar o limite da linha
-      if (currentLine.length + word.length + 1 > maxLineLength) {
-        // Se a linha atual não estiver vazia, finalize-a
-        if (currentLine.length > 0) {
-          lines.push(currentLine.trim());
-          currentLine = word;
-        } else {
-          // Se a palavra é muito longa para caber em uma linha, force-a
-          lines.push(word);
-          currentLine = "";
-        }
-      } else {
-        // Adicione a palavra à linha atual
-        currentLine += (currentLine.length > 0 ? " " : "") + word;
-      }
-    });
-
-    // Adicione a última linha se houver
-    if (currentLine.length > 0) {
-      lines.push(currentLine.trim());
-    }
-
-    return lines.join("\n");
-  }
-
-  /**
    * Layout do Nível 3: Botões de texto (sem imagens)
    */
   private createLevel3Layout(
@@ -452,9 +418,6 @@ export default class HygieneLogic {
     options.forEach((option, index) => {
       const { x, y } = positions[index];
 
-      // Aplicar quebra de linha automática no texto
-      const wrappedText = this.wrapText(option);
-
       const button = this.buttonFactory.createButton({
         positions: { x, y },
         textures: {
@@ -462,11 +425,18 @@ export default class HygieneLogic {
           hover: "hoverButton",
           clicked: "clickedButton",
         },
-        text: wrappedText,
+        text: option,
         fontSize: 32,
         scale: 1,
         onClick: () => this.handleButtonClick(option),
       });
+
+      // Aplicar word wrap ao texto do botão após criação
+      const buttonText = button.getButtonText();
+      if (buttonText) {
+        buttonText.setWordWrapWidth(280);
+        buttonText.setAlign("center");
+      }
 
       this.buttons.push(button);
     });

--- a/src/games/plants/logic/PlantsLogic.ts
+++ b/src/games/plants/logic/PlantsLogic.ts
@@ -290,6 +290,13 @@ export default class PlantsLogic {
           onClick: () => this.handleButtonClick(option),
         });
 
+        // Aplicar word wrap ao texto do botão após criação
+        const buttonText = button.getButtonText();
+        if (buttonText) {
+          buttonText.setWordWrapWidth(280);
+          buttonText.setAlign("center");
+        }
+
         this.buttons.push(button);
       }
     });

--- a/src/games/space/logic/SpaceLogic.ts
+++ b/src/games/space/logic/SpaceLogic.ts
@@ -219,6 +219,13 @@ export default class SpaceLogic {
           onClick: () => this.handleButtonClick(option),
         });
 
+        // Aplicar word wrap ao texto do botão após criação
+        const buttonText = button.getButtonText();
+        if (buttonText) {
+          buttonText.setWordWrapWidth(280);
+          buttonText.setAlign("center");
+        }
+
         this.buttons.push(button);
       }
     });


### PR DESCRIPTION
# Descrição

Essa PR adiciona quebra de linha para os textos caberem dentro do botão na fase 3 dos jogos que usam botões só com texto

Essa PR endereça a(s) tarefa(s) #<task_id>, #<task_id>, #<task_id>...

Essa PR tem como dependências o(s) PR(s) #<pr_id>, #<pr_id>, #<pr_id>...

# Tipo de alterações realizadas

<Marque todas as opções relevantes>

- [X] Correção de bug (alteração que corrige um problema)
- [ ] Novo recurso (adição de novas funcionalidades)
- [ ] Refatoração (uma mudança no código que não corrige um problema nem adiciona novas funcionalidades)
- [ ] Breaking change (correção ou nova funcionalidade que pode causar mau funcionamento de outras funcionalidades existentes)
- [ ] Atualizações de tarefas de build, configurações de administrador, pacotes... (como por exemplo adicionar um pacote no gitignore.)

# Como testar

<Por favor, descreva quaisquer instruções relevantes para executar, testar e verificar as mudanças feitas.>

# Checklist

- [X] Meu código segue as diretrizes de estilo especificadas no guia de estilo do projeto
- [X] Realizei a revisão do meu próprio código
- [X] Realizei as alterações necessárias na documentação
- [X] Minhas mudanças não geram novos "code warnings" ou erros
- [ ] Adicionei testes que cobrem o novo código adicionado
- [ ] Os novos testes e também os já existentes passam localmente com minhas mudanças
